### PR TITLE
Feat/rhf and zod

### DIFF
--- a/docs/form_validation.md
+++ b/docs/form_validation.md
@@ -1,0 +1,92 @@
+# 📋 README — Правила использования RHF + Zod + zodResolver
+
+# ❗ Обязательные правила
+
+## 1️. Использовать только Zod v3
+
+Причина:
+
+- `zod/v4` несовместима с `@hookform/resolvers`
+- Использование v4 приводит к некорректной работе `zodResolver`
+
+**Валидация строго через Zod**
+
+Вся логика валидации должна находиться исключительно в Zod-схеме.
+
+`import { z } from "zod/v3"`
+
+---
+
+## Запрещено:
+
+- использовать required в register
+
+- писать inline-валидаторы
+
+- делать проверки внутри onSubmit
+
+- добавлять ручные проверки (if (!value))
+
+- дублировать логику валидации
+
+Пример правильной схемы:
+
+```ts
+const schema = z.object({
+  email: z.string().min(1, 'Email обязателен').email('Некорректный email'),
+  password: z.string().min(6, 'Минимум 6 символов'),
+});
+```
+
+Все сообщения об ошибках должны быть определены внутри схемы.
+
+---
+
+## 2. Обязательно использовать zodResolver
+
+Форма должна быть подключена через zodResolver.
+
+```ts
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+type FormValues = z.infer<typeof schema>;
+const {
+  register,
+  handleSubmit,
+  formState: { errors },
+} = useForm<FormValues>({
+  resolver: zodResolver(schema),
+});
+```
+
+---
+
+## Использовать только handleSubmit
+
+Запрещено писать кастомный `onSubmit с preventDefault`.
+
+**Неправильно:**
+
+```ts
+const onSubmit = (e) => {
+  e.preventDefault();
+};
+```
+
+Правильно:
+
+```ts
+const onSubmit = (data: FormValues) => {
+console.log(data)
+}
+
+<form onSubmit={handleSubmit(onSubmit)}>
+```
+
+---
+
+## пизация только через z.infer
+
+Типы формы должны выводиться из схемы.
+
+`type FormValues = z.infer<typeof schema>`

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.90.21",
     "axios": "^1.13.5",
     "class-variance-authority": "^0.7.1",
@@ -25,14 +26,23 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "tailwind-merge": "^3.4.1"
+    "react-hook-form": "^7.71.1",
+    "tailwind-merge": "^3.4.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@chromatic-com/storybook": "^5.0.1",
     "@dreamsicle.io/stylelint-config-tailwindcss": "^1.2.2",
+    "@storybook/addon-a11y": "^10.2.9",
+    "@storybook/addon-docs": "^10.2.9",
+    "@storybook/addon-vitest": "^10.2.9",
+    "@storybook/nextjs-vite": "^10.2.9",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitest/browser-playwright": "^4.0.18",
+    "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "eslint-config-prettier": "^10.1.8",
@@ -40,10 +50,13 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-simple-import-sort": "^12.1.1",
+    "eslint-plugin-storybook": "^10.2.9",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
+    "playwright": "^1.58.2",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "shadcn": "^3.8.5",
+    "storybook": "^10.2.9",
     "stylelint": "^17.3.0",
     "stylelint-config-recess-order": "^7.6.1",
     "stylelint-config-standard": "^40.0.0",
@@ -52,18 +65,8 @@
     "tsc-files": "^1.1.4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5",
-    "storybook": "^10.2.9",
-    "@storybook/nextjs-vite": "^10.2.9",
-    "@chromatic-com/storybook": "^5.0.1",
-    "@storybook/addon-vitest": "^10.2.9",
-    "@storybook/addon-a11y": "^10.2.9",
-    "@storybook/addon-docs": "^10.2.9",
     "vite": "^7.3.1",
-    "eslint-plugin-storybook": "^10.2.9",
-    "vitest": "^4.0.18",
-    "playwright": "^1.58.2",
-    "@vitest/browser-playwright": "^4.0.18",
-    "@vitest/coverage-v8": "^4.0.18"
+    "vitest": "^4.0.18"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.71.1(react@19.2.3))
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.3)
@@ -34,9 +37,15 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      react-hook-form:
+        specifier: ^7.71.1
+        version: 7.71.1(react@19.2.3)
       tailwind-merge:
         specifier: ^3.4.1
         version: 3.4.1
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^5.0.1
@@ -852,6 +861,14 @@ packages:
     engines: { node: '>=18.14.1' }
     peerDependencies:
       hono: ^4
+
+  '@hookform/resolvers@5.2.2':
+    resolution:
+      {
+        integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==,
+      }
+    peerDependencies:
+      react-hook-form: ^7.55.0
 
   '@humanfs/core@0.19.1':
     resolution:
@@ -2557,6 +2574,12 @@ packages:
     resolution:
       {
         integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
+      }
+
+  '@standard-schema/utils@0.3.0':
+    resolution:
+      {
+        integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==,
       }
 
   '@storybook/addon-a11y@10.2.9':
@@ -6925,6 +6948,15 @@ packages:
     peerDependencies:
       react: ^19.2.3
 
+  react-hook-form@7.71.1:
+    resolution:
+      {
+        integrity: sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==,
+      }
+    engines: { node: '>=18.0.0' }
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution:
       {
@@ -8756,6 +8788,11 @@ snapshots:
     dependencies:
       hono: 4.11.9
 
+  '@hookform/resolvers@5.2.2(react-hook-form@7.71.1(react@19.2.3))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.71.1(react@19.2.3)
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -9879,6 +9916,8 @@ snapshots:
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@storybook/addon-a11y@10.2.9(storybook@10.2.9(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
@@ -12603,6 +12642,10 @@ snapshots:
     dependencies:
       react: 19.2.3
       scheduler: 0.27.0
+
+  react-hook-form@7.71.1(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   react-is@16.13.1: {}
 

--- a/src/shared/lib/form/ExampleForm.shema.ts
+++ b/src/shared/lib/form/ExampleForm.shema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod/v3';
+
+export const exampleSchema = z.object({
+  useremail: z
+    .string()
+    .nonempty('Поле обязательно')
+    .email('Введите корректный email'),
+  password: z
+    .string()
+    .nonempty('Поле обязательно')
+    .min(8, 'Пароль должен быть не меньше 8 символов')
+    .regex(/[A-Z]/, 'Добавьте хотя бы одну заглавную букву')
+    .regex(/[a-z]/, 'Добавьте хотя бы одну строчную букву')
+    .regex(/[0-9]/, 'Добавьте хотя бы одну цифру')
+    .regex(/[^A-Za-z0-9]/, 'Добавьте хотя бы один спецсимвол'),
+});
+
+export type ExampleFormTypes = z.infer<typeof exampleSchema>;

--- a/src/shared/lib/form/ExampleForm.tsx
+++ b/src/shared/lib/form/ExampleForm.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { Button } from '../../ui/button';
+import { Input } from '../../ui/input';
+import { Label } from '../../ui/label';
+import { getFieldError } from '../helpers/getFieldError';
+
+import { type ExampleFormTypes, exampleSchema } from './ExampleForm.shema';
+
+export function ExampleForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<ExampleFormTypes>({
+    resolver: zodResolver(exampleSchema),
+    mode: 'onBlur',
+  });
+
+  const onSubmit = (data: ExampleFormTypes) => {
+    console.log(
+      `user data: email - ${data.useremail}, password -  ${data.password}`,
+    );
+    reset({ password: '', useremail: '' });
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className='mx-auto grid max-w-3/10 gap-y-3 py-5'
+    >
+      <Label htmlFor='user-email'>Email:</Label>
+      <Input
+        {...register('useremail', {
+          required: true,
+        })}
+        id='user-email'
+        placeholder='Email...'
+      />
+      {getFieldError(errors, 'useremail') && (
+        <span>{getFieldError(errors, 'useremail')}</span>
+      )}
+      <Label htmlFor='user-password'>Password:</Label>
+      <Input
+        {...register('password', {
+          required: true,
+        })}
+        id='user-password'
+        placeholder='Password...'
+      />
+      {getFieldError(errors, 'password') && (
+        <span>{getFieldError(errors, 'password')}</span>
+      )}
+      <Button type='submit' className='w-2/10 justify-self-center'>
+        Send
+      </Button>
+    </form>
+  );
+}

--- a/src/shared/lib/form/ExapleForm.stories.tsx
+++ b/src/shared/lib/form/ExapleForm.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { ExampleForm } from './ExampleForm';
+
+const meta: Meta<typeof ExampleForm> = {
+  title: 'Shared/Form/ExampleForm',
+  component: ExampleForm,
+};
+
+export default meta;
+type Story = StoryObj<typeof ExampleForm>;
+
+// Story по умолчанию
+export const Default: Story = {};
+
+export const Prefilled: Story = {
+  render: () => <ExampleForm />,
+};

--- a/src/shared/lib/form/index.ts
+++ b/src/shared/lib/form/index.ts
@@ -1,0 +1,1 @@
+export { ExampleForm } from './ExampleForm';

--- a/src/shared/lib/helpers/getFieldError.ts
+++ b/src/shared/lib/helpers/getFieldError.ts
@@ -1,0 +1,6 @@
+import type { FieldErrors } from 'react-hook-form';
+
+export const getFieldError = <T extends Record<string, unknown>>(
+  errors: FieldErrors<T>,
+  field: keyof T,
+) => errors[field]?.message;


### PR DESCRIPTION
## Настройка валидации форм (Zod + RHF)

Что сделано:
- Добавлен Zod для схемной валидации
- Подключён React Hook Form (RHF)
- Добавлен @hookform/resolvers с использованием zodResolver
- Создан пример формы в shared/lib/form/ExampleForm.tsx
- Добавлена схема формы (лежит в папке form)
- Написаны stories для формы (Storybook)
- Добавлена документация docs/form_validation.md

## Структура:
```
shared/lib/form/
 ├── ExampleForm.tsx
 ├── schema.ts
 ├── ExampleForm.stories.tsx
```

## Документация:

- docs/form_validation.md содержит:
- описание подхода к валидации
- пример создания схемы
- подключение Zod к RHF