### PR TITLE
fix: replace tsc-files with @jonasgeiler/tsc-files

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^5.0.1",
     "@dreamsicle.io/stylelint-config-tailwindcss": "^1.2.2",
+    "@jonasgeiler/tsc-files": "^2.3.1",
     "@storybook/addon-a11y": "^10.2.9",
     "@storybook/addon-docs": "^10.2.9",
     "@storybook/addon-vitest": "^10.2.9",
@@ -67,7 +68,6 @@
     "stylelint-config-standard": "^40.0.0",
     "stylelint-order": "^7.0.1",
     "tailwindcss": "^4",
-    "tsc-files": "^1.1.4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5",
     "vite": "^7.3.1",


### PR DESCRIPTION
## Что сделано
- Удалён пакет `tsc-files` (devDependency)
- Установлен форк `@jonasgeiler/tsc-files`

## Зачем
Оригинальный `tsc-files` некорректно работает с pnpm: при прогоне type-check через lint-staged (pre-commit) не находит ошибки TypeScript. Форк [@jonasgeiler/tsc-files](https://www.npmjs.com/package/@jonasgeiler/tsc-files) исправляет это поведение.

## Изменения
- **package.json**: в devDependencies вместо `tsc-files` указан `@jonasgeiler/tsc-files`
- **.lintstagedrc.mjs**: без изменений — форк экспортирует тот же бинарник `tsc-files`, команда `tsc-files --noEmit` остаётся