### PR TITLE
fix window

### DIFF
--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -31,7 +31,14 @@ interface EnvType {
   WATCHPACK_POLLING: string;
 }
 
-export const env: EnvType = {
-  ...process.env,
-  ...window.env,
-};
+// Собираем env без доступа к window на этапе оценки модуля (SSR/build).
+// window.env используется только в браузере (runtime, например Docker).
+function buildEnv(): EnvType {
+  const base = { ...process.env } as unknown as EnvType;
+  if (typeof window !== 'undefined' && window.env) {
+    return { ...base, ...window.env };
+  }
+  return base;
+}
+
+export const env: EnvType = buildEnv();


### PR DESCRIPTION
Что сделано:
1. Найдена причина ошибки. В src/shared/config/env.ts при загрузке модуля выполнялось ...window.env. Этот файл тянется в корень приложения по цепочке: layout -> AuthProvider -> entities/session -> api -> env. При серверном рендере и при генерации статики модуль выполняется на сервере, где нет window -> ReferenceError: window is not defined.
2. Сделана правка в env.ts Значение env теперь собирается в функции buildEnv(): на сервере используется только process.env, а window.env читается только при typeof window !== 'undefined'. Так мы не обращаемся к window на этапе оценки модуля при SSR/build.