### PR TITLE
Fix/auth initial refresh tocken fix

### DIFF
--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -27,7 +27,7 @@ export default function AuthProvider({
   const [isRefreshDone, setIsRefreshDone] = useState(isLoginPage);
   const isFirstMount = useRef(true);
 
-  const { data, isSuccess, isError, isPending } = useAuthMeQuery({
+  const { data, isSuccess, isError, isLoading } = useAuthMeQuery({
     enabled: isRefreshDone && isAuth,
   });
 
@@ -73,7 +73,7 @@ export default function AuthProvider({
     isLoginPage,
   ]);
 
-  if (!isRefreshDone || isPending) return null;
+  if (!isRefreshDone || isLoading) return null;
 
   return <>{children}</>;
 }

--- a/src/app/providers/interceptor/useInterceptor.ts
+++ b/src/app/providers/interceptor/useInterceptor.ts
@@ -27,8 +27,9 @@ export default function useInterceptor() {
       async (error) => {
         const status = error.response?.status ?? 0;
         const data = error.response?.data;
+        const originalUrl = error.config?.url ?? '';
 
-        if (status !== 401) {
+        if (status !== 401 || originalUrl.includes('/auth/refresh')) {
           return Promise.reject(new ApiError(status, data));
         }
 


### PR DESCRIPTION
Проблема
При переходе на страницы вроде /test  приложение показывало белую страницу и не рендерило контент. 

Причины
- Дедлок в интерцепторе Axios. Инициализационный запрос POST /auth/refresh шёл через тот же $api, у которого на 401 срабатывает интерцептор и снова вызывается refreshToken(). При 401 от самого refresh (например, нет refresh-cookie) интерцептор ждал тот же промис, который ждал завершения первого запроса - промис не резолвился, isRefreshDone не становился true, AuthProvider всегда возвращал null.

- Некорректная проверка в AuthProvider. Использовался isPending из useAuthMeQuery. В TanStack Query v5 у отключённого запроса (enabled: false) isPending остаётся true, поэтому после неудачного refresh условие !isRefreshDone || isPending всегда выполнялось и рендер блокировался.

Решение
- useInterceptor.ts: при 401 не вызывать refresh, если упавший запрос - сам /auth/refresh (проверка по error.config?.url). Для таких ответов сразу пробрасывать ошибку.
- AuthProvider.tsx: в условии блокировки рендера использовать isLoading вместо isPending, чтобы отключённый запрос /auth/me не считался "в процессе" и не блокировал отображение страницы.